### PR TITLE
Add Gemfile for Jekyll

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+gem "jekyll", "~> 4.3"
+


### PR DESCRIPTION
## Summary
- add Gemfile with Jekyll dependency

## Testing
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68c5646ae7e48324a0c610fca6a68649